### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,18 @@
+
+
+# Blog de Zisheng
+
+[![紫升](https://img.shields.io/website-up-down-green-red/https/blog.zisheng.pro.svg)](https://blog.zisheng.pro)
+[![紫升](https://img.shields.io/badge/Made%20with-Markdown-1f425f.svg)](https://guides.github.com/features/mastering-markdown/)
+
+## Ruta de aprendizaje de Frontend
+
+![紫升](https://i.loli.net/2021/03/31/hYFQxyzriawD93k.png)
+
+## Ruta de aprendizaje de Backend
+
+![紫升](https://i.loli.net/2021/03/31/adMZ9hxfGolt3CH.png)
+
+## Ruta de aprendizaje de DevOps
+
+![紫升](https://i.loli.net/2021/03/31/HTJUfCPLwQ31t87.png)


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `qwen3.6-35b-a3b via local API`.